### PR TITLE
Chnage 'src/' to 'src'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "hive-thrift-py",
-    version = "0.0.1",
+    version = "0.0.2",
     author = "Youngwoo Kim",
     author_email = "warwithin@gmail.com",
     description = ("Hive Python Thrift Libs"),
@@ -11,7 +11,7 @@ setup(
     license = "Apache License",
     keywords = "hive hadoop thrift",
     url = "http://hive.apache.org",
-    packages=find_packages('src/'),
+    packages=find_packages('src'),
     package_dir = {'':'src'},
     zip_safe = True,
 )


### PR DESCRIPTION
"src/" does not work on windows. 'src' is universal. It's works on linux and windows